### PR TITLE
Update install.md，修改错误的环境变量名

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -128,9 +128,9 @@ export GOPEED_ADDRESS="0.0.0.0"
 export GOPEED_PORT="9999"
 export GOPEED_USERNAME="gopeed"
 export GOPEED_PASSWORD="xxx"
-export GOPEED_API_TOKEN=""
-export GOPEED_STORAGE_DIR=""
-export GOPEED_WHITE_DOWNLOAD_DIRS="/root/downloads,/root/dir/*,/root/dir?abc"
+export GOPEED_APITOKEN=""
+export GOPEED_STORAGEDIR=""
+export GOPEED_WHITEDOWNLOADDIRS="/root/downloads,/root/dir/*,/root/dir?abc"
 ```
 
 > Note: If you are deploying on a public IP, please ensure to enable identity authentication, otherwise there will be security risks.

--- a/docs/zh-TW/install.md
+++ b/docs/zh-TW/install.md
@@ -128,9 +128,9 @@ export GOPEED_ADDRESS="0.0.0.0"
 export GOPEED_PORT="9999"
 export GOPEED_USERNAME="gopeed"
 export GOPEED_PASSWORD="xxx"
-export GOPEED_API_TOKEN=""
-export GOPEED_STORAGE_DIR=""
-export GOPEED_WHITE_DOWNLOAD_DIRS="/root/downloads,/root/dir/*,/root/dir?abc"
+export GOPEED_APITOKEN=""
+export GOPEED_STORAGEDIR=""
+export GOPEED_WHITEDOWNLOADDIRS="/root/downloads,/root/dir/*,/root/dir?abc"
 ```
 
 > 注意：如果你是在公網 ip 部署，請務必啟用身份認證，否則會有安全風險。

--- a/docs/zh/install.md
+++ b/docs/zh/install.md
@@ -128,9 +128,9 @@ export GOPEED_ADDRESS="0.0.0.0"
 export GOPEED_PORT="9999"
 export GOPEED_USERNAME="gopeed"
 export GOPEED_PASSWORD="xxx"
-export GOPEED_API_TOKEN=""
-export GOPEED_STORAGE_DIR=""
-export GOPEED_WHITE_DOWNLOAD_DIRS="/root/downloads,/root/dir/*,/root/dir?abc"
+export GOPEED_APITOKEN=""
+export GOPEED_STORAGEDIR=""
+export GOPEED_WHITEDOWNLOADDIRS="/root/downloads,/root/dir/*,/root/dir?abc"
 ```
 
 > 注：如果在公网 ip 上进行部署，请务必启用身份认证，否则会有安全风险。


### PR DESCRIPTION
我使用docker 部署的时候，使用GOPEED_API_TOKEN作为环境变量，但发现不生效，怎么尝试都不行，然后查询代码，在[源码测试文档](https://github.com/GopeedLab/gopeed/blob/cfdcb586ee451b97001a523f0726d8d4f06ffa42/cmd/web/flags_test.go#L226)中发现了正确应该是GOPEED_APITOKEN，而不是GOPEED_API_TOKEN，这和文档中的不一致